### PR TITLE
👍 devもawsにデプロイできるように

### DIFF
--- a/.ecspresso/dev/ecs-service-def.json
+++ b/.ecspresso/dev/ecs-service-def.json
@@ -1,0 +1,56 @@
+{
+	"deploymentConfiguration": {
+		"alarms": {
+			"alarmNames": ["rollback-alert"],
+			"enable": true,
+			"rollback": true
+		},
+		"deploymentCircuitBreaker": {
+			"enable": true,
+			"rollback": true
+		},
+		"maximumPercent": 200,
+		"minimumHealthyPercent": 100
+	},
+	"healthCheckGracePeriodSeconds": 60,
+	"deploymentController": {
+		"type": "ECS"
+	},
+	"capacityProviderStrategy": [
+		{
+			"capacityProvider": "FARGATE",
+			"base": 1,
+			"weight": 1
+		}
+	],
+	"loadBalancers": [
+		{
+			"containerName": "analysis",
+			"containerPort": 8000,
+			"targetGroupArn": "{{ ssm `/kotohiro-dev-analysis-tg/arn` }}"
+		}
+	],
+	"networkConfiguration": {
+		"awsvpcConfiguration": {
+			"assignPublicIp": "ENABLED",
+			"securityGroups": ["{{ ssm `/kotohiro-dev-analysis-sg/id`}}"],
+			"subnets": [
+				"{{ ssm `/kotohiro-dev-public-subnet/0/id` }}",
+				"{{ ssm `/kotohiro-dev-public-subnet/1/id` }}"
+			]
+		}
+	},
+	"enableECSManagedTags": false,
+	"enableExecuteCommand": true,
+	"desiredCount": 1,
+	"schedulingStrategy": "REPLICA",
+	"platformVersion": "LATEST",
+	"platformFamily": "Linux",
+	"propagateTags": "NONE",
+	"tags": [
+		{
+			"key": "Name",
+			"value": "kotohiro-dev-analysis"
+		}
+	]
+}

--- a/.ecspresso/dev/ecs-task-def.json
+++ b/.ecspresso/dev/ecs-task-def.json
@@ -56,8 +56,8 @@
 	"cpu": "256",
 	"memory": "512",
 	"family": "kotohiro-dev-analysis",
-	"taskRoleArn": "{{ ssm `/kotohiro-dev-analysis-task-role/arn` }}",
-	"executionRoleArn": "{{ ssm `/kotohiro-dev-analysis-task-execution-role/arn` }}",
+	"taskRoleArn": "{{ ssm `/kotohiro-dev-task-role/arn` }}",
+	"executionRoleArn": "{{ ssm `/kotohiro-dev-task-execution-role/arn` }}",
 	"networkMode": "awsvpc",
 	"requiresCompatibilities": ["FARGATE"],
 	"runtimePlatform": {

--- a/.ecspresso/dev/ecs-task-def.json
+++ b/.ecspresso/dev/ecs-task-def.json
@@ -1,0 +1,80 @@
+{
+	"containerDefinitions": [
+		{
+			"essential": true,
+			"name": "analysis",
+			"image": "{{ ssm `/kotohiro-dev-analysis-rep/uri` }}:{{ must_env `IMAGE_TAG` }}",
+			"environment": [],
+			"secrets": [
+				{
+					"name": "DATABASE_URL",
+					"valueFrom": "{{ ssm `/kotohiro-dev-app-secret/arn` }}:DATABASE_URL::"
+				},
+				{
+					"name": "ANALYSIS_USER",
+					"valueFrom": "{{ ssm `/kotohiro-dev-app-secret/arn` }}:ANALYSIS_USER::"
+				},
+				{
+					"name": "ANALYSIS_USER_PASSWORD",
+					"valueFrom": "{{ ssm `/kotohiro-dev-app-secret/arn` }}:ANALYSIS_USER_PASSWORD::"
+				},
+				{
+					"name": "MODEL_ID",
+					"valueFrom": "{{ ssm `/kotohiro-dev-app-secret/arn` }}:MODEL_ID::"
+				}
+			],
+			"logConfiguration": {
+				"logDriver": "awslogs",
+				"options": {
+					"awslogs-group": "{{ ssm `/kotohiro-dev-analysis-log-group/name` }}",
+					"awslogs-region": "ap-northeast-1",
+					"awslogs-stream-prefix": "development"
+				}
+			},
+			"portMappings": [
+				{
+					"appProtocol": "http",
+					"containerPort": 8000,
+					"hostPort": 8000,
+					"protocol": "tcp"
+				}
+			],
+			"mountPoints": [
+				{
+					"readOnly": false,
+					"containerPath": "/var/lib/amazon",
+					"sourceVolume": "var-lib-amazon"
+				},
+				{
+					"readOnly": false,
+					"containerPath": "/var/log/amazon",
+					"sourceVolume": "var-log-amazon"
+				}
+			]
+		}
+	],
+	"cpu": "256",
+	"memory": "512",
+	"family": "kotohiro-dev-analysis",
+	"taskRoleArn": "{{ ssm `/kotohiro-dev-analysis-task-role/arn` }}",
+	"executionRoleArn": "{{ ssm `/kotohiro-dev-analysis-task-execution-role/arn` }}",
+	"networkMode": "awsvpc",
+	"requiresCompatibilities": ["FARGATE"],
+	"runtimePlatform": {
+		"cpuArchitecture": "ARM64"
+	},
+	"tags": [
+		{
+			"key": "Name",
+			"value": "kotohiro-dev-task-definition"
+		}
+	],
+	"volumes": [
+		{
+			"name": "var-lib-amazon"
+		},
+		{
+			"name": "var-log-amazon"
+		}
+	]
+}

--- a/.ecspresso/dev/ecspresso.yml
+++ b/.ecspresso/dev/ecspresso.yml
@@ -1,0 +1,8 @@
+region: ap-northeast-1
+cluster: kotohiro-dev-cluster
+service: kotohiro-dev-analysis
+service_definition: ecs-service-def.json
+task_definition: ecs-task-def.json
+timeout: "10m0s"
+plugins:
+  - name: ssm

--- a/.ecspresso/prod/ecs-service-def.json
+++ b/.ecspresso/prod/ecs-service-def.json
@@ -32,11 +32,11 @@
 	],
 	"networkConfiguration": {
 		"awsvpcConfiguration": {
-			"assignPublicIp": "DISABLED",
+			"assignPublicIp": "ENABLED",
 			"securityGroups": ["{{ ssm `/kotohiro-prd-analysis-sg/id`}}"],
 			"subnets": [
-				"{{ ssm `/kotohiro-prd-private-subnet/0/id` }}",
-				"{{ ssm `/kotohiro-prd-private-subnet/1/id` }}"
+				"{{ ssm `/kotohiro-prd-public-subnet/0/id` }}",
+				"{{ ssm `/kotohiro-prd-public-subnet/1/id` }}"
 			]
 		}
 	},

--- a/.ecspresso/prod/ecs-task-def.json
+++ b/.ecspresso/prod/ecs-task-def.json
@@ -56,8 +56,8 @@
 	"cpu": "256",
 	"memory": "512",
 	"family": "kotohiro-prd-analysis",
-	"taskRoleArn": "{{ ssm `/kotohiro-prd-analysis-task-role/arn` }}",
-	"executionRoleArn": "{{ ssm `/kotohiro-prd-analysis-task-execution-role/arn` }}",
+	"taskRoleArn": "{{ ssm `/kotohiro-prd-task-role/arn` }}",
+	"executionRoleArn": "{{ ssm `/kotohiro-prd-task-execution-role/arn` }}",
 	"networkMode": "awsvpc",
 	"requiresCompatibilities": ["FARGATE"],
 	"runtimePlatform": {

--- a/scripts/db-connect
+++ b/scripts/db-connect
@@ -140,3 +140,4 @@ echo ""
 psql "postgresql://${RDS_USERNAME}:$(urlencode "$RDS_PASSWORD")@localhost:${RDS_PORT}/${RDS_DATABASE}" "$@"
 
 echo ""
+kill $PF_PID &2>/dev/null

--- a/scripts/db-connect
+++ b/scripts/db-connect
@@ -16,7 +16,15 @@ fi
 ENV="$1"
 shift  # 最初の引数（環境）を削除して、残りをpsqlに渡す
 
-source scripts/utils.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/utils.sh"
+
+PROJECT_ROOT=$(find_project_root)
+if [ -z "$PROJECT_ROOT" ]; then
+    echo "エラー: .ecspressoディレクトリが見つかりません"
+    echo "プロジェクトのルートディレクトリに.ecspressoディレクトリが存在することを確認してください"
+    exit 1
+fi
 
 ACCOUNT_ID=$(login_aws $AWS_PROFILE)
 if [ -z "$ACCOUNT_ID" ]; then
@@ -49,6 +57,14 @@ case "$ENV" in
         exit 1
         ;;
 esac
+
+ECSPRESSO_CONFIG="${PROJECT_ROOT}/.ecspresso/${ENV}/ecspresso.yml"
+# 設定ファイルの存在確認
+if [ ! -f "$ECSPRESSO_CONFIG" ]; then
+    echo "エラー: ecspresso設定ファイルが見つかりません: $ECSPRESSO_CONFIG"
+    exit 1
+fi
+echo "$ECSPRESSO_CONFIG"
 
 echo "SSMからシークレットARNを取得中..."
 SECRET_ARN=$(aws ssm get-parameter --name "$SSM_PARAM_NAME" --query 'Parameter.Value' --output text 2>/dev/null)
@@ -84,7 +100,7 @@ fi
 
 echo "${ENV}環境のECSタスクを検索中..."
 id=$(
-    ecspresso tasks --config ./.ecspresso/api/${ENV}/ecspresso.yml --output=json 2>/dev/null | \
+    ecspresso tasks --config "$ECSPRESSO_CONFIG" --output=json 2>/dev/null | \
     jq -r '.containers[0].taskArn | split("/")[2]' | \
     head -1
 )
@@ -99,7 +115,7 @@ echo "タスクID: $id"
 echo "ポートフォワード開始..."
 echo "localhost:5432 → ${RDS_ENDPOINT}:${RDS_PORT}"
 
-ecspresso exec --config ./.ecspresso/${ENV}/ecspresso.yml \
+ecspresso exec --config "$ECSPRESSO_CONFIG" \
     --port-forward -L 5432:${RDS_ENDPOINT}:${RDS_PORT} --id $id &
 
 PF_PID=$!

--- a/scripts/db-connect
+++ b/scripts/db-connect
@@ -99,7 +99,7 @@ echo "タスクID: $id"
 echo "ポートフォワード開始..."
 echo "localhost:5432 → ${RDS_ENDPOINT}:${RDS_PORT}"
 
-ecspresso exec --config ./.ecspresso/api/${ENV}/ecspresso.yml \
+ecspresso exec --config ./.ecspresso/${ENV}/ecspresso.yml \
     --port-forward -L 5432:${RDS_ENDPOINT}:${RDS_PORT} --id $id &
 
 PF_PID=$!

--- a/scripts/db-connect
+++ b/scripts/db-connect
@@ -124,6 +124,10 @@ if ! kill -0 $PF_PID 2>/dev/null; then
     echo "エラー: ポートフォワードの開始に失敗しました"
     exit 1
 fi
+cleanup() {
+    kill $PF_PID 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
 
 # ポートフォワードが確立されるまで待機
 echo "接続待機中..."
@@ -156,4 +160,3 @@ echo ""
 psql "postgresql://${RDS_USERNAME}:$(urlencode "$RDS_PASSWORD")@localhost:${RDS_PORT}/${RDS_DATABASE}" "$@"
 
 echo ""
-kill $PF_PID &2>/dev/null

--- a/scripts/db-connect
+++ b/scripts/db-connect
@@ -1,0 +1,142 @@
+#!/bin/bash
+
+if [ $# -eq 0 ]; then
+    echo "エラー: 環境を指定してください"
+    echo "使い方: $0 <dev|prd> [psql引数...]"
+    echo "例: "
+    echo "  $0 dev                          # 通常の接続"
+    echo "  $0 dev -c \"SELECT 1\"            # SQLを実行"
+    echo "  $0 dev -f dump.sql              # SQLファイルを実行"
+    echo ""
+    echo "ダンプを取得する場合:"
+    echo "  $0 dev -c \"\\copy (SELECT * FROM users) TO STDOUT WITH CSV HEADER\" > users.csv"
+    exit 1
+fi
+
+ENV="$1"
+shift  # 最初の引数（環境）を削除して、残りをpsqlに渡す
+
+source scripts/utils.sh
+
+ACCOUNT_ID=$(login_aws $AWS_PROFILE)
+if [ -z "$ACCOUNT_ID" ]; then
+    echo "AWS認証に失敗しました" >&2
+    exit 1
+fi
+
+case "$ENV" in
+    "dev")
+        SSM_PARAM_NAME="/kotohiro-dev-db-secret/arn"
+        ;;
+    "prd"|"prod")
+        SSM_PARAM_NAME="/kotohiro-prd-db-secret/arn"
+
+        echo "⚠️  注意: 本番環境のデータベースに接続しようとしています！"
+        echo -n "本当に接続しますか？ (yes/no): "
+        read confirmation
+
+        if [ "$confirmation" != "yes" ]; then
+            echo "接続をキャンセルしました"
+            exit 0
+        fi
+
+        # 環境名を統一
+        ENV="prd"
+        ;;
+    *)
+        echo "エラー: '$ENV' は無効な環境です"
+        echo "有効な環境: dev, prd (または prod)"
+        exit 1
+        ;;
+esac
+
+echo "SSMからシークレットARNを取得中..."
+SECRET_ARN=$(aws ssm get-parameter --name "$SSM_PARAM_NAME" --query 'Parameter.Value' --output text 2>/dev/null)
+
+if [ $? -ne 0 ] || [ -z "$SECRET_ARN" ]; then
+    echo "エラー: SSMパラメータの取得に失敗しました"
+    echo "パラメータ名: $SSM_PARAM_NAME"
+    echo "AWS認証情報とパラメータ名を確認してください"
+    exit 1
+fi
+
+echo "データベース接続情報を取得中..."
+SECRET=$(aws secretsmanager get-secret-value --secret-id $SECRET_ARN --query 'SecretString' --output text 2>/dev/null)
+
+if [ $? -ne 0 ]; then
+    echo "エラー: Secrets Managerからの取得に失敗しました"
+    echo "AWS認証情報と権限を確認してください"
+    exit 1
+fi
+
+RDS_ENDPOINT=$(echo $SECRET | jq -r '.host // .endpoint // .address')
+RDS_PORT=$(echo $SECRET | jq -r '.port // "5432"')
+RDS_USERNAME=$(echo $SECRET | jq -r '.username // .user')
+RDS_PASSWORD=$(echo $SECRET | jq -r '.password')
+RDS_DATABASE=$(echo $SECRET | jq -r '.database // .dbname // .engine')
+
+if [ -z "$RDS_ENDPOINT" ] || [ "$RDS_ENDPOINT" = "null" ]; then
+    echo "エラー: RDSエンドポイントが見つかりません"
+    echo "利用可能なキー:"
+    echo $SECRET | jq -r 'keys[]'
+    exit 1
+fi
+
+echo "${ENV}環境のECSタスクを検索中..."
+id=$(
+    ecspresso tasks --config ./.ecspresso/api/${ENV}/ecspresso.yml --output=json 2>/dev/null | \
+    jq -r '.containers[0].taskArn | split("/")[2]' | \
+    head -1
+)
+
+if [ -z "$id" ]; then
+    echo "エラー: ${ENV}環境で実行中のECSタスクが見つかりません"
+    echo "タスクが起動していることを確認してください"
+    exit 1
+fi
+
+echo "タスクID: $id"
+echo "ポートフォワード開始..."
+echo "localhost:5432 → ${RDS_ENDPOINT}:${RDS_PORT}"
+
+ecspresso exec --config ./.ecspresso/api/${ENV}/ecspresso.yml \
+    --port-forward -L 5432:${RDS_ENDPOINT}:${RDS_PORT} --id $id &
+
+PF_PID=$!
+
+if ! kill -0 $PF_PID 2>/dev/null; then
+    echo "エラー: ポートフォワードの開始に失敗しました"
+    exit 1
+fi
+
+# ポートフォワードが確立されるまで待機
+echo "接続待機中..."
+echo ""
+echo "--- ecspresso ---"
+for i in {1..10}; do
+    if nc -z localhost 5432 2>/dev/null; then
+        break
+    fi
+    if [ $i -eq 10 ]; then
+        echo "------"
+        echo ""
+        echo "エラー: ポートフォワードの確立に失敗しました"
+        kill $PF_PID 2>/dev/null
+        exit 1
+    fi
+    sleep 1
+done
+
+sleep 2 # ecspressoの出力が落ち着くまで少し待機
+echo "------"
+echo ""
+echo "======================================="
+echo "環境: $ENV"
+echo "DB名: $RDS_DATABASE"
+echo "ユーザー: $RDS_USERNAME"
+echo "======================================="
+echo ""
+
+psql "postgresql://${RDS_USERNAME}:$(urlencode "$RDS_PASSWORD")@localhost:${RDS_PORT}/${RDS_DATABASE}" "$@"
+
+echo ""

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -34,10 +34,6 @@ else
     ECR_REPO="kotohiro-dev-api"
 fi
 
-if [ -z "$ECR_REPO_URI" ]; then
-    echo "Failed to get ECR repository URI from SSM parameter" >&2
-    exit 1
-fi
 TAG=$ACCOUNT_ID.dkr.ecr.ap-northeast-1.amazonaws.com/$ECR_REPO:$IMAGE_TAG
 
 docker build -f server/Dockerfile . -t $TAG --no-cache

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -29,9 +29,9 @@ TIMESTAMP=$(date '+%s%3')
 export IMAGE_TAG=$COMMIT_HASH$TIMESTAMP
 
 if [ "$ENV" = "prod" ]; then
-    ECR_REPO="kotohiro-prd-api"
+    ECR_REPO="kotohiro-prd-analysis"
 else
-    ECR_REPO="kotohiro-dev-api"
+    ECR_REPO="kotohiro-dev-analysis"
 fi
 
 TAG=$ACCOUNT_ID.dkr.ecr.ap-northeast-1.amazonaws.com/$ECR_REPO:$IMAGE_TAG

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -13,7 +13,22 @@ if [ "$ENV" != "dev" ] && [ "$ENV" != "prod" ]; then
     exit 1
 fi
 
-source scripts/utils.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/utils.sh"
+
+PROJECT_ROOT=$(find_project_root)
+if [ -z "$PROJECT_ROOT" ]; then
+    echo "エラー: .ecspressoディレクトリが見つかりません"
+    echo "プロジェクトのルートディレクトリに.ecspressoディレクトリが存在することを確認してください"
+    exit 1
+fi
+
+ECSPRESSO_CONFIG="${PROJECT_ROOT}/.ecspresso/${ENV}/ecspresso.yml"
+# 設定ファイルの存在確認
+if [ ! -f "$ECSPRESSO_CONFIG" ]; then
+    echo "エラー: ecspresso設定ファイルが見つかりません: $ECSPRESSO_CONFIG"
+    exit 1
+fi
 
 export ACCOUNT_ID=$(login_aws $AWS_PROFILE)
 if [ -z "$ACCOUNT_ID" ]; then
@@ -39,4 +54,4 @@ TAG=$ACCOUNT_ID.dkr.ecr.ap-northeast-1.amazonaws.com/$ECR_REPO:$IMAGE_TAG
 docker build -f server/Dockerfile . -t $TAG --no-cache
 docker push $TAG
 
-ecspresso deploy --config ./.ecspresso/$ENV/ecspresso.yml --force-new-deployment
+ecspresso deploy --config "$ECSPRESSO_CONFIG" --force-new-deployment

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -14,3 +14,20 @@ login_aws() {
   fi
   echo $ACCOUNT_ID
 }
+
+urlencode() {
+    local string="${1}"
+    local strlen=${#string}
+    local encoded=""
+    local pos c o
+
+    for (( pos=0 ; pos<strlen ; pos++ )); do
+        c=${string:$pos:1}
+        case "$c" in
+            [-_.~a-zA-Z0-9] ) o="${c}" ;;
+            * ) printf -v o '%%%02x' "'$c" ;;
+        esac
+        encoded+="${o}"
+    done
+    echo "${encoded}"
+}

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -31,3 +31,15 @@ urlencode() {
     done
     echo "${encoded}"
 }
+
+find_project_root() {
+    local current_dir="$SCRIPT_DIR"
+    while [ "$current_dir" != "/" ]; do
+        if [ -d "$current_dir/.ecspresso" ]; then
+            echo "$current_dir"
+            return 0
+        fi
+        current_dir="$(dirname "$current_dir")"
+    done
+    return 1
+}


### PR DESCRIPTION
# やったこと

- dev用のecspresso設定を追加
- デプロイスクリプトでdev, prod選択できるように
- dbのポートフォワード用のスクリプト追加
- prodのサブネットをpublicに -> NATGateway削除するため

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - 開発/本番向けのECSサービス・タスク定義を追加（Fargate、コンテナ公開、ECS Exec有効、ログ・ボリューム・シークレット注入、デプロイ設定含む）。
  - 環境別のecspresso設定を追加（デプロイ先・タイムアウト・SSM参照）。
  - RDSへ安全に接続するポートフォワード用コマンドを追加（日本語メッセージ、prodは確認プロンプト付き）。
- 改善
  - デプロイスクリプトがdev/prod引数に対応し環境別ECRリポジトリと設定を自動選択。
  - 本番ネットワークをパブリックIP有効・パブリックサブネットへ変更、タスクのロール参照を環境用に切替え。
  - URLエンコードとプロジェクトルート検出の補助関数を追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->